### PR TITLE
allow "." directory path to specify the root of `files`

### DIFF
--- a/src/examples/files.jl
+++ b/src/examples/files.jl
@@ -7,6 +7,9 @@ export files
 Base.joinpath() = ""
 
 function validpath(root, path; dirs = true)
+  if normpath(root) == "."
+    root = pwd()
+  end
   full = normpath(root, path)
   startswith(full, root) &&
     (isfile(full) || (dirs && isdir(full)))


### PR DESCRIPTION
Now the following file server works:

``` julia
using Mux

@app foo = (
    Mux.defaults,
    files("."),
    Mux.notfound())

serve(foo)
```
