### PR TITLE
symbol ⇒ Symbol

### DIFF
--- a/src/routing.jl
+++ b/src/routing.jl
@@ -19,7 +19,7 @@ function matchpath(target, path)
   params = d()
   for i = 1:length(target)
     if startswith(target[i], ":")
-      params[symbol(target[i][2:end])] = path[i]
+      params[Symbol(target[i][2:end])] = path[i]
     else
       target[i] == path[i] || return
     end


### PR DESCRIPTION
Pretty trivial change. I think this is the only deprecation that needs to be fixed here in Mux (the core is really very small!). Tests work when Hiccup is checked out, but latest tagged Hiccup is pretty broken on nightly. So let's hope that Mux's Hiccup dependency is not tested here (it seems to only be used in one file).