### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,15 @@ os:
   - osx
 julia:
   - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("Mux")'
-  - julia -e 'Pkg.test("Mux", coverage=true)'
+git:
+  depth: 999999
+#script: # use the default script which is equivalent to the following
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Mux")'
+#  - julia -e 'Pkg.test("Mux", coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("Mux")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'


### PR DESCRIPTION
set `git: depth:` to work around `git fetch --unshallow` failing on Linux

use default `script:` setting

add separate testing against `0.5`