### PR TITLE
Serve package asset files

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,3 +191,7 @@ For example:
 * `respond(x)` – creates an endpoint that responds with `x`, regardless of the request.
 * `route("/path/here", app)` – branches to `app` if the request location matches `"/path/here"`.
 * `page("/path/here", app)` – branches to `app` if the request location *exactly* matches `"/path/here"`
+
+## Serving static files from a package
+
+The `Mux.pkgfiles` middleware (included in `Mux.defaults`) serves static files under the `assets` directory in any Julia package at `/pkg/<PACKAGE>/`.

--- a/src/Mux.jl
+++ b/src/Mux.jl
@@ -30,7 +30,7 @@ include("websockets_integration.jl")
 include("examples/basic.jl")
 include("examples/files.jl")
 
-defaults = stack(todict, basiccatch, splitquery, toresponse)
+defaults = stack(todict, basiccatch, splitquery, toresponse, pkgfiles)
 wdefaults = stack(todict, wcatch, splitquery)
 
 end

--- a/src/examples/files.jl
+++ b/src/examples/files.jl
@@ -52,3 +52,12 @@ dirresponse(f) =
             div(".box", table([tr(td(".file", filelink(f, x)),
                                   td(".size", string(filesize(joinpath(f, x)))))
                                for x in ["..", readdir(f)...]]))))
+
+const ASSETS_DIR = "assets"
+function packagefiles(dirs=true)
+    absdir(req) = Pkg.dir(req[:params][:pkg], ASSETS_DIR)
+    branch(req -> validpath(absdir(req), joinpath(req[:path]...), dirs=dirs),
+           req -> fresp(joinpath(absdir(req), req[:path]...)))
+end
+
+const pkgfiles = route("pkg/:pkg", packagefiles(), Mux.notfound())


### PR DESCRIPTION
A file at `MyPkg/assets/js/test.js` will be served at `/pkg/MyPkg/js/test.js`

supersedes https://github.com/JunoLab/Blink.jl/pull/55