### PR TITLE
Scheme based routing (WIP)

### DIFF
--- a/src/routing.jl
+++ b/src/routing.jl
@@ -1,6 +1,6 @@
-using HttpCommon
+using HttpCommon, URIParser
 
-export method, GET, route, page, probabilty
+export method, GET, scheme, HTTP, HTTPS, route, page, probabilty
 
 # Request type
 
@@ -8,6 +8,19 @@ method(m::AbstractString, app...) = branch(req -> req[:method] == m, app...)
 method(ms, app...) = branch(req -> req[:method] in ms, app...)
 
 GET(app...) = method("GET", app...)
+
+#URL scheme type
+
+function getscheme(req)
+  uri = URI(req.uri)
+  return uri.scheme
+end
+
+scheme(scm::AbstractString, app...) = branch(req -> getscheme(req) == scm, app...)
+scheme(scms, app...) = branch(req -> getscheme(req) in scms, app...)
+
+HTTPS(app...) = scheme("HTTPS", app...)
+HTTP(app...) = scheme("HTTP", app...)
 
 # Path routing
 


### PR DESCRIPTION
There are 2 problems:

1. When I try to test it on a localhost `uri` (from `uri = req.uri`) doesn't return the complete URI. It just returns `:/` where as the address used is http://localhost:8000. As a result `uri.scheme` is empty. So I am not sure if `scheme` function works, don't know how to test it.

2. Using `Mux.defaults` converts a `req` to a dict and this dict doesn't have anything like `req[:uri]`. So I have used `req.uri` which means `Mux.defaults` can't be used. A possible solution is to add `req'[:uri] = req.uri` [here](https://github.com/JuliaWeb/Mux.jl/blob/master/src/basics.jl#L12).

``` julia
using Mux
using Base.Test
using Lazy
import Requests
@app test = (
  #Mux.defaults,
  #page("/dum", respond("<h1>Boo!</h1>")),
  scheme("http", respond("<h1>http</h1>")),
  scheme("https", respond("<h1>https</h1>")),
  #GET(respond("<h1>get!</h1>")),
  Mux.notfound())
serve(test)
@test Requests.text(Requests.get("http://localhost:8000/dum")) == "<h1>http</h1>"
```
It fails. Someone please give me some pointers. @MikeInnes 