### PR TITLE
[WIP] Add wrap cookies middleware

### DIFF
--- a/src/Mux.jl
+++ b/src/Mux.jl
@@ -24,6 +24,7 @@ using Hiccup
 include("server.jl")
 include("basics.jl")
 include("routing.jl")
+include("wrap_cookies.jl")
 
 include("websockets_integration.jl")
 

--- a/src/basics.jl
+++ b/src/basics.jl
@@ -32,12 +32,16 @@ params!(req) = get!(req, :params, d())
 
 # Response
 
-import HttpCommon: Response
+import HttpCommon: Response, Cookie
+
+Response(s::Int, h::HttpCommon.Headers, d::HttpCommon.HttpData, c::Dict) =
+  Response(s, h, c, d, Nullable(), Response[], false, Request[])
 
 Response(d::Associative) =
   Response(get(d, :status, 200),
            convert(Headers, get(d, :headers, HttpCommon.headers())),
-           get(d, :body, ""))
+           get(d, :body, ""),
+           get(d, :cookies, Dict{String, Cookie}()))
 
 Response(o) = Response(stringmime(MIME"text/html"(), o))
 

--- a/src/wrap_cookies.jl
+++ b/src/wrap_cookies.jl
@@ -1,0 +1,16 @@
+export wrap_cookies
+
+function wrap_cookies(app, req)
+  response    = app(req)
+  cookies     = get(response, "cookies", Dict{String, Cookie}())
+
+  cookies_dic = Dict{String, Cookie}()
+  for (name, dic) in cookies
+    cookies_dic[name] = Cookie(name, dic["value"])
+  end
+
+  response["cookies"] = cookies_dic
+
+  response
+end
+

--- a/src/wrap_cookies.jl
+++ b/src/wrap_cookies.jl
@@ -1,16 +1,56 @@
 export wrap_cookies
 
+import Base.==
+==(a::Cookie, b::Cookie) = a.name == b.name && a.value == b.value && a.attrs == b.attrs
+
+function same_site_value(value)
+  Dict("strict" => "Strict", "lax" => "Lax")[value]
+end
+
+function set_cookie_attrs(attrs::Dict)
+  attrs_name_map = Dict("domain" => "Domain", "max-age" => "Max-Age", "path" => "Path",
+                        "secure" => "Secure", "expires" => "Expires", "http-only" => "HttpOnly",
+                        "same-site" => "SameSite")
+
+  cookie_attrs = Dict{String, String}()
+  for (name, value) in attrs
+    if name != "value"
+      attr_name = attrs_name_map[name]
+      if value == true
+        cookie_attrs[attr_name] = ""
+      elseif value != false
+        if name == "same-site"
+          value = same_site_value(value)
+        elseif name == "expires"
+          if typeof(value) == Date
+            value = Dates.format(value, Dates.RFC1123Format)
+          else
+            value = Dates.format(DateTime(value), Dates.RFC1123Format)
+          end
+        elseif name == "max-age"
+          if typeof(value) != String && typeof(value) != Int
+            value = convert(Dates.Second, value).value
+          end
+        end
+
+        cookie_attrs[attr_name] = string(value)
+      end
+    end
+  end
+
+  cookie_attrs
+end
+
 function wrap_cookies(app, req)
   response    = app(req)
-  cookies     = get(response, "cookies", Dict{String, Cookie}())
+  cookies     = get(response, :cookies, Dict{String, Cookie}())
 
   cookies_dic = Dict{String, Cookie}()
   for (name, dic) in cookies
-    cookies_dic[name] = Cookie(name, dic["value"])
+    cookies_dic[name] = Cookie(name, dic["value"], set_cookie_attrs(dic))
   end
 
-  response["cookies"] = cookies_dic
+  response[:cookies] = cookies_dic
 
   response
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,5 +23,16 @@ serve(test)
 # Test Response d::Associative
 import HttpCommon: Response, Cookie
 
+import Base.==
+==(a::Cookie, b::Cookie) = a.name == b.name && a.value == b.value && a.attrs == b.attrs
+
 response = Response(Dict(:status => 400, :cookies => Dict("cookies" => Cookie("cookie-name", "value"))))
 @test response.cookies["cookies"].name == "cookie-name"
+
+
+identity(arg) = arg
+response = Dict{String,Any}("cookies" => Dict("a" => Dict("value" => "b"),
+                                              "c" => Dict("value" => "d")))
+cookies = Mux.wrap_cookies(identity, response)["cookies"]
+@test cookies ==
+    Dict{Any,Any}("a" => Cookie("a", "b"), "c" => Cookie("c", "d"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,3 +19,9 @@ serve(test)
             "<h1>Boo!</h1>"
 @test Requests.text(Requests.get("http://localhost:8000/user/julia")) ==
             "<h1>Hello, julia!</h1>"
+
+# Test Response d::Associative
+import HttpCommon: Response, Cookie
+
+response = Response(Dict(:status => 400, :cookies => Dict("cookies" => Cookie("cookie-name", "value"))))
+@test response.cookies["cookies"].name == "cookie-name"


### PR DESCRIPTION
The wrap_cookies is similar to [ring's wrap-cookies](https://github.com/ring-clojure/ring/blob/master/ring-core/src/ring/middleware/cookies.clj#L137).

1. user can set cookies in dic, and `wrap_cookies` will covert it to right type for response
2. `wrap_cookies` let user handle cookie's attributes easily.

But it doesn't have decode/encode abilities, I plan to add those abilities in next pull request.
