### PR TITLE
break words for error message page

### DIFF
--- a/src/basics.jl
+++ b/src/basics.jl
@@ -56,7 +56,7 @@ status(s) = reskey(:status, s)
 
 mux_css = """
   body { font-family: sans-serif; padding:50px; }
-  .box { background: #fcfcff; padding:20px; border: 1px solid #ddd; border-radius:5px; }
+  .box { background: #fcfcff; padding:20px; border: 1px solid #ddd; border-radius:5px; white-space: pre-wrap; word-wrap: break-word; }
   pre { line-height:1.5 }
   a { text-decoration:none; color:#225; }
   a:hover { color:#336; }


### PR DESCRIPTION
Sometimes the error messages are too long.
I think `break word` will let user read the message more easily.

Screen shot:

<img width="1225" alt="screen shot 2017-04-30 at 7 52 56 pm" src="https://cloud.githubusercontent.com/assets/3775525/25564151/f53a46a8-2dde-11e7-9c56-41b749e3c764.png">
