### PR TITLE
AssetRegistry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
-  - 0.5
+  - 0.6
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 git:

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,5 +4,6 @@ Hiccup
 HttpCommon
 HttpServer
 URIParser
+AssetRegistry
 WebSockets
 Compat 0.7.9

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.6
 Lazy
 Hiccup
 HttpCommon

--- a/src/Mux.jl
+++ b/src/Mux.jl
@@ -30,7 +30,7 @@ include("websockets_integration.jl")
 include("examples/basic.jl")
 include("examples/files.jl")
 
-defaults = stack(todict, basiccatch, splitquery, toresponse, pkgfiles)
+defaults = stack(todict, basiccatch, splitquery, toresponse, assetserver, pkgfiles)
 wdefaults = stack(todict, wcatch, splitquery)
 
 end

--- a/src/examples/files.jl
+++ b/src/examples/files.jl
@@ -57,7 +57,23 @@ const ASSETS_DIR = "assets"
 function packagefiles(dirs=true)
     absdir(req) = Pkg.dir(req[:params][:pkg], ASSETS_DIR)
     branch(req -> validpath(absdir(req), joinpath(req[:path]...), dirs=dirs),
-           req -> fresp(joinpath(absdir(req), req[:path]...)))
+           req -> (Base.warn_once("""
+                        Relying on /pkg/ is now deprecated. Please use the package 
+                        `AssetRegistry.jl` instead to register assets directory
+                        """);
+                   fresp(joinpath(absdir(req), req[:path]...))))
 end
 
 const pkgfiles = route("pkg/:pkg", packagefiles(), Mux.notfound())
+
+
+using AssetRegistry
+
+function assetserve(dirs=true)
+    absdir(req) = AssetRegistry.registry["/assetserver/" * req[:params][:key]]
+    branch(req -> (isfile(absdir(req)) && isempty(req[:path])) || 
+           validpath(absdir(req), joinpath(req[:path]...), dirs=dirs),
+           req -> fresp(joinpath(absdir(req), req[:path]...)))
+end
+
+const assetserver = route("assetserver/:key", assetserve(), Mux.notfound())


### PR DESCRIPTION
Introduce a common package which holds a key -> path dictionary of files to serve by default in Mux.

Packages interested in serving static files can register with this base package without depending on Mux.