### PR TITLE
enable precompilation

### DIFF
--- a/src/Mux.jl
+++ b/src/Mux.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module Mux
 
 export mux, stack, branch


### PR DESCRIPTION
See log http://juliarun-ci.s3.amazonaws.com/ca683dcf21cca54bea956d5705f03fb45796d6ea/pull_request_of_WebIO_on_julia_0_6.log for METADATA PR https://github.com/JuliaLang/METADATA.jl/pull/15399.

> INFO: Building WebIO
WARNING: Module Mux with uuid 6556077278318599 is missing from the cache.
This may mean module Mux does not support precompilation but is imported by a module that does.
ERROR: LoadError: LoadError: Declaring __precompile__(false) is not allowed in files that are being precompiled.