### PR TITLE
turn websockets integration back on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,12 @@ os:
   - osx
 julia:
   - 0.7
+  - 1.0
   - nightly
 matrix:
   allow_failures:
     - julia: nightly
 notifications:
   email: false
-git:
-  depth: 999999
-#script: # use the default script which is equivalent to the following
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Mux")'
-#  - julia -e 'Pkg.test("Mux", coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("Mux")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  - julia -e 'using Pkg; import Mux; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7-
+julia 0.7
 Lazy
 Hiccup
 AssetRegistry

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.7
 Lazy
 Hiccup
 AssetRegistry
-WebSockets
-HTTP
+WebSockets 1.0.0
+HTTP 0.6.14

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,11 @@ platform:
   - x86 # 32-bit
   - x64 # 64-bit
 
-# # Uncomment the following lines to allow failures on nightly julia
-# # (tests will run but not make your overall status red)
-# matrix:
-#   allow_failures:
-#   - julia_version: latest
+# Uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - julia_version: nightly
 
 branches:
   only:

--- a/src/websockets_integration.jl
+++ b/src/websockets_integration.jl
@@ -1,22 +1,22 @@
-#using WebSockets
-#
-#function todict(rc::Tuple{Request, WebSocket})
-#  req, client = rc
-#  req′ = todict(req)
-#  req′[:socket] = client
-#  return req′
-#end
+using WebSockets: WebSocket
+
+function todict(rc::Tuple{Request, WebSocket})
+ req, client = rc
+ req′ = todict(req)
+ req′[:socket] = client
+ return req′
+end
 
 function wcatch(app, req)
   try
     app(req)
   catch e
-    println(STDERR, "Error handling websocket connection:")
-    showerror(STDERR, e, catch_backtrace())
+    println(stderr, "Error handling websocket connection:")
+    showerror(stderr, e, catch_backtrace())
   end
 end
 
-function wclose(req)
+function wclose(_, req)
   close(req[:socket])
 end
 


### PR DESCRIPTION
This is necessary to get WebIO.jl working again on 0.7