### PR TITLE
Recommend against using defaults in Production

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,13 @@ end
 
 Now, if you run both programs, you'll see a `Hello World` message, as the
 server is replying the same message back to the client.
+
+## Using Mux in Production
+
+While Mux should be perfectly useable in a Production environment, it is not
+recommended to use the `Mux.defaults` stack for a Production application. The
+`basiccatch` middleware it includes will dump potentially sensitive stacktraces
+to the client on error, which is probably not what you want to be serving to
+your clients! An alternative `Mux.prod_defaults` stack is available for
+Production applications, which is just `Mux.defaults` with a `stderrcatch`
+middleware instead (which dumps errors to stderr).

--- a/src/Mux.jl
+++ b/src/Mux.jl
@@ -33,5 +33,6 @@ include("examples/files.jl")
 
 defaults = stack(todict, basiccatch, splitquery, toresponse, assetserver, pkgfiles)
 wdefaults = stack(todict, wcatch, splitquery)
+prod_defaults = stack(todict, stderrcatch, splitquery, toresponse, assetserver, pkgfiles)
 
 end

--- a/src/basics.jl
+++ b/src/basics.jl
@@ -93,3 +93,12 @@ function basiccatch(app, req)
     return d(:status => 500, :body => codeunits(String(take!(io))))
   end
 end
+
+function stderrcatch(app, req)
+  try
+    app(req)
+  catch e
+    showerror(stderr, e, catch_backtrace())
+    return d(:status => 500, :body => codeunits("Internal server error"))
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,3 +46,24 @@ end
 @test String(HTTP.get("http://localhost:8000/dum?one=1&two=hfjd").body) ==
             "<h1>query2</h1>"
 @test_throws StatusError String(HTTP.get("http://localhost:8000/dum?one=1&two=2&sarv=boo").body)
+
+throwapp() = (_...) -> error("An error!")
+
+# Test production server
+@app test = (
+  Mux.prod_defaults,
+  page("/",respond("<h1>Hello World!</h1>")),
+  page("/about", respond("<h1>Boo!</h1>")),
+  page("/user/:user", req -> "<h1>Hello, $(req[:params][:user])!</h1>"),
+  throwapp(),
+  Mux.notfound())
+serve(test, 8001)
+@test String(HTTP.get("http://localhost:8001").body) ==
+            "<h1>Hello World!</h1>"
+@test String(HTTP.get("http://localhost:8001/about").body) ==
+            "<h1>Boo!</h1>"
+@test String(HTTP.get("http://localhost:8001/user/julia").body) ==
+            "<h1>Hello, julia!</h1>"
+@test String(HTTP.get("http://localhost:8001/badurl";
+                      status_exception=false).body) ==
+             "Internal server error"


### PR DESCRIPTION
While `Mux.defaults` is great for development and debugging purposes, it
should definitely not be used in a Production application, due to the
inclusion of the `basiccatch` middleware, which dumps stacktraces to
clients. Reword the README to indicate that one should instead roll
their own stack.