### PR TITLE
support assetserving of files with spaces

### DIFF
--- a/src/examples/files.jl
+++ b/src/examples/files.jl
@@ -77,10 +77,11 @@ const pkgfiles = route("pkg/:pkg", packagefiles(), Mux.notfound())
 using AssetRegistry
 
 function assetserve(dirs=true)
-    absdir(req) = AssetRegistry.registry["/assetserver/" * req[:params][:key]]
+    absdir(req) = AssetRegistry.registry["/assetserver/" * HTTP.unescapeuri(req[:params][:key])]
+    path(req) = HTTP.unescapeuri.(req[:path])
     branch(req -> (isfile(absdir(req)) && isempty(req[:path])) ||
-           validpath(absdir(req), joinpath(req[:path]...), dirs=dirs),
-           req -> fresp(joinpath(absdir(req), req[:path]...)))
+           validpath(absdir(req), joinpath(path(req)...), dirs=dirs),
+           req -> fresp(joinpath(absdir(req), path(req)...)))
 end
 
 const assetserver = route("assetserver/:key", assetserve(), Mux.notfound())


### PR DESCRIPTION
Currently assetserving fails when files contain spaces or other url-forbidden characters.

I propose to modify `assetserve()` in order to solve that issue.