### PR TITLE
bump minor version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Mux"
 uuid = "a975b10e-0019-58db-a62f-e48ff68538c9"
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 AssetRegistry = "bf4720bc-e11a-5d0c-854e-bdca1663c893"


### PR DESCRIPTION
Apparently, d0abb2a9f2ed41b13381eaf9d6231a274e84afde never made it into a release. Could someone also tag a new release once this is merged?