### PR TITLE
Make a minor release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Mux"
 uuid = "a975b10e-0019-58db-a62f-e48ff68538c9"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 AssetRegistry = "bf4720bc-e11a-5d0c-854e-bdca1663c893"


### PR DESCRIPTION
There is a [CompatHelper upgrade to Lazy](https://github.com/JuliaWeb/Mux.jl/commit/7cbc92cea995849656396511d174c322f67bab08) that needs to make it out to release. 

Fix #110