### PR TITLE
Rename "probabilty" -> "probability"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Mux"
 uuid = "a975b10e-0019-58db-a62f-e48ff68538c9"
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 AssetRegistry = "bf4720bc-e11a-5d0c-854e-bdca1663c893"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ using Mux
   Mux.defaults,
   page(respond("<h1>Hello World!</h1>")),
   page("/about",
-       probabilty(0.1, respond("<h1>Boo!</h1>")),
+       probability(0.1, respond("<h1>Boo!</h1>")),
        respond("<h1>About Me</h1>")),
   page("/user/:user", req -> "<h1>Hello, $(req[:params][:user])!</h1>"),
   Mux.notfound())
@@ -169,7 +169,7 @@ mux(branch(_ -> rand() < 0.1, respond("Hello")),
 We can also define a function to wrap the branch
 
 ```jl
-probabilty(x, app) = branch(_ -> rand() < x, app)
+probability(x, app) = branch(_ -> rand() < x, app)
 ```
 
 ### Utilities

--- a/src/routing.jl
+++ b/src/routing.jl
@@ -1,6 +1,6 @@
 import HTTP
 
-export method, GET, route, page, probabilty, query
+export method, GET, route, page, probability, query
 
 # Request type
 
@@ -64,4 +64,6 @@ query(q::Dict{<:AbstractString, <:AbstractString}, app...) =
 
 # Misc
 
-probabilty(x, app...) = branch(_->rand()<x, app...)
+probability(x, app...) = branch(_->rand()<x, app...)
+# Old typo
+@deprecate probabilty(x, app...) probability(x, app...)


### PR DESCRIPTION
It's a typo. I don't know if this is worth doing or not, though!