### PR TITLE
Fix stack overflows with page(func, func)

### DIFF
--- a/src/routing.jl
+++ b/src/routing.jl
@@ -43,6 +43,7 @@ page(p::Vector, app...) = branch(req -> length(p) == length(req[:path]) && match
 page(p::AbstractString, app...) = page(splitpath(p), app...)
 page(app...) = page([], app...)
 page(app::Function, p) = page(p, app)
+page(app1::Function, app2::Function) = page([], app1, app2)
 
 # Query routing
 

--- a/src/routing.jl
+++ b/src/routing.jl
@@ -35,9 +35,11 @@ function matchpath!(target, req)
   return true
 end
 
-route(p, app...) = branch(req -> matchpath!(p, req), app...)
+route(p::Vector, app...) = branch(req -> matchpath!(p, req), app...)
 route(p::AbstractString, app...) = route(splitpath(p), app...)
+route(app...) = route([], app...)
 route(app::Function, p) = route(p, app)
+route(app1::Function, app2::Function) = route([], app1, app2)
 
 page(p::Vector, app...) = branch(req -> length(p) == length(req[:path]) && matchpath!(p, req), app...)
 page(p::AbstractString, app...) = page(splitpath(p), app...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,9 +68,12 @@ serve(test, 8001)
                       status_exception=false).body) ==
              "Internal server error"
 
-# Test page() callable without a string argument
+# Test page and route are callable without a string argument
+# (previously the first two raised StackOverflowError)
 @test page(identity, identity) isa Function
+@test route(identity, identity) isa Function
 @test page(identity) isa Function
+@test route(identity) isa Function
 
 # Test you can pass the string last if you really want.
 @test page(identity, "") isa Function

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,3 +67,11 @@ serve(test, 8001)
 @test String(HTTP.get("http://localhost:8001/badurl";
                       status_exception=false).body) ==
              "Internal server error"
+
+# Test page() callable without a string argument
+@test page(identity, identity) isa Function
+@test page(identity) isa Function
+
+# Test you can pass the string last if you really want.
+@test page(identity, "") isa Function
+@test route(identity, "") isa Function


### PR DESCRIPTION
Maybe these are no big deal, but I think if passing 1 or 3 functions to `page` calls `page([], app...)`, 2 functions should also call that.

I think another decent option would be to deprecate `page(func, path)`.

Also applies to `route`.