### PR TITLE
Test WebSockets and reorganise tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,88 +3,115 @@ using Test
 using HTTP
 import HTTP.ExceptionRequest: StatusError
 
-@test Mux.notfound()(Dict())[:status] == 404
-d1 = Dict("one"=> "1", "two"=> "2")
-d2 = Dict("one"=> "1", "two"=> "")
-# Test basic server
-@app test = (
-  Mux.defaults,
-  page("/",respond("<h1>Hello World!</h1>")),
-  page("/about", respond("<h1>Boo!</h1>")),
-  page("/user/:user", req -> "<h1>Hello, $(req[:params][:user])!</h1>"),
-  query(d1, respond("<h1>query1</h1>")),
-  query(d2, respond("<h1>query2</h1>")),
-  Mux.notfound())
-serve(test)
-@test String(HTTP.get("http://localhost:8000").body) ==
-            "<h1>Hello World!</h1>"
-@test String(HTTP.get("http://localhost:8000/about").body) ==
-            "<h1>Boo!</h1>"
-@test String(HTTP.get("http://localhost:8000/user/julia").body) ==
-            "<h1>Hello, julia!</h1>"
+@testset "misc" begin
+  function f()
+    @app foo = (Mux.defaults)
+  end
 
-# Issue #68
-@test Mux.fileheaders("foo.css")["Content-Type"] == "text/css"
-@test Mux.fileheaders("foo.html")["Content-Type"] == "text/html"
-@test Mux.fileheaders("foo.js")["Content-Type"] == "application/javascript"
+  @test f() == nothing
 
-function f()
-  @app foo = (Mux.defaults)
+  @test Mux.notfound()(Dict())[:status] == 404
 end
 
-@test f() == nothing
 
-# Query based routing
-@test String(HTTP.get("http://localhost:8000/dum?one=1&two=2").body) ==
-            "<h1>query1</h1>"
-@test_throws StatusError String(HTTP.get("http://localhost:8000/dum?one=1").body)
-@test_throws StatusError String(HTTP.get("http://localhost:8000/dum?one=1&two=2&sarv=boo").body)
-@test_throws StatusError String(HTTP.get("http://localhost:8000/dum?one=1").body)
-@test String(HTTP.get("http://localhost:8000/dum?one=1&two=56").body) ==
-            "<h1>query2</h1>"
-@test String(HTTP.get("http://localhost:8000/dum?one=1&two=hfjd").body) ==
-            "<h1>query2</h1>"
-@test_throws StatusError String(HTTP.get("http://localhost:8000/dum?one=1&two=2&sarv=boo").body)
+@testset "basic server" begin
+  d1 = Dict("one"=> "1", "two"=> "2")
+  d2 = Dict("one"=> "1", "two"=> "")
+  @app test = (
+    Mux.defaults,
+    page("/",respond("<h1>Hello World!</h1>")),
+    page("/about", respond("<h1>Boo!</h1>")),
+    page("/user/:user", req -> "<h1>Hello, $(req[:params][:user])!</h1>"),
+    query(d1, respond("<h1>query1</h1>")),
+    query(d2, respond("<h1>query2</h1>")),
+    Mux.notfound())
+  serve(test)
 
-throwapp() = (_...) -> error("An error!")
-# Used for wrapping stderrcatch so we can check its output and stop it spewing
-# all over the test results.
-path, mock_stderr = mktemp()
+  @testset "page" begin
+    @test String(HTTP.get("http://localhost:8000").body) ==
+                "<h1>Hello World!</h1>"
+    @test String(HTTP.get("http://localhost:8000/about").body) ==
+                "<h1>Boo!</h1>"
+    @test String(HTTP.get("http://localhost:8000/user/julia").body) ==
+                "<h1>Hello, julia!</h1>"
+  end
 
-# Test production server
-@app test = (
-  Mux.prod_defaults,
-  (app, req) -> redirect_stderr(() -> Mux.stderrcatch(app, req), mock_stderr),
-  page("/",respond("<h1>Hello World!</h1>")),
-  page("/about", respond("<h1>Boo!</h1>")),
-  page("/user/:user", req -> "<h1>Hello, $(req[:params][:user])!</h1>"),
-  throwapp(),
-  Mux.notfound())
-serve(test, 8001)
-@test String(HTTP.get("http://localhost:8001").body) ==
-            "<h1>Hello World!</h1>"
-@test String(HTTP.get("http://localhost:8001/about").body) ==
-            "<h1>Boo!</h1>"
-@test String(HTTP.get("http://localhost:8001/user/julia").body) ==
-            "<h1>Hello, julia!</h1>"
-@test String(HTTP.get("http://localhost:8001/badurl";
-                      status_exception=false).body) ==
-             "Internal server error"
-seekstart(mock_stderr)
-@test occursin("An error!", read(mock_stderr, String))
-close(mock_stderr)
-rm(path)
+  @testset "query" begin
+    @test String(HTTP.get("http://localhost:8000/dum?one=1&two=2").body) ==
+                "<h1>query1</h1>"
+    @test_throws StatusError String(HTTP.get("http://localhost:8000/dum?one=1").body)
+    @test_throws StatusError String(HTTP.get("http://localhost:8000/dum?one=1&two=2&sarv=boo").body)
+    @test_throws StatusError String(HTTP.get("http://localhost:8000/dum?one=1").body)
+
+    @test String(HTTP.get("http://localhost:8000/dum?one=1&two=56").body) ==
+                "<h1>query2</h1>"
+    @test String(HTTP.get("http://localhost:8000/dum?one=1&two=hfjd").body) ==
+                "<h1>query2</h1>"
+    @test_throws StatusError String(HTTP.get("http://localhost:8000/dum?one=1").body)
+    @test_throws StatusError String(HTTP.get("http://localhost:8000/dum?one=1&two=2&sarv=boo").body)
+  end
+end
+
+
+@testset "MIME types" begin
+  # Issue #68
+  @test Mux.fileheaders("foo.css")["Content-Type"] == "text/css"
+  @test Mux.fileheaders("foo.html")["Content-Type"] == "text/html"
+  @test Mux.fileheaders("foo.js")["Content-Type"] == "application/javascript"
+end
+
+
+# Check that prod_defaults don't completely break things
+# And check prod_defaults error handler
+@testset "prod defaults" begin
+  throwapp() = (_...) -> error("An error!")
+
+  # Used for wrapping stderrcatch so we can check its output and stop it spewing
+  # all over the test results.
+  path, mock_stderr = mktemp()
+
+  @app test = (
+    Mux.prod_defaults,
+    (app, req) -> redirect_stderr(() -> Mux.stderrcatch(app, req), mock_stderr),
+    page("/",respond("<h1>Hello World!</h1>")),
+    page("/about", respond("<h1>Boo!</h1>")),
+    page("/user/:user", req -> "<h1>Hello, $(req[:params][:user])!</h1>"),
+    throwapp(),
+    Mux.notfound())
+
+  serve(test, 8001)
+
+  @test String(HTTP.get("http://localhost:8001").body) ==
+              "<h1>Hello World!</h1>"
+  @test String(HTTP.get("http://localhost:8001/about").body) ==
+              "<h1>Boo!</h1>"
+  @test String(HTTP.get("http://localhost:8001/user/julia").body) ==
+              "<h1>Hello, julia!</h1>"
+  @test String(HTTP.get("http://localhost:8001/badurl";
+                        status_exception=false).body) ==
+               "Internal server error"
+
+  # Check our error was logged and close fake stderr
+  seekstart(mock_stderr)
+  @test occursin("An error!", read(mock_stderr, String))
+  close(mock_stderr)
+  rm(path)
+end
+
 
 # Test page and route are callable without a string argument
 # (previously the first two raised StackOverflowError)
-@test page(identity, identity) isa Function
-@test route(identity, identity) isa Function
-@test page(identity) isa Function
-@test route(identity) isa Function
+@testset "bare page()" begin
+  @test page(identity, identity) isa Function
+  @test route(identity, identity) isa Function
+  @test page(identity) isa Function
+  @test route(identity) isa Function
 
-# Test you can pass the string last if you really want.
-@test page(identity, "") isa Function
-@test route(identity, "") isa Function
+  # Test you can pass the string last if you really want.
+  @test page(identity, "") isa Function
+  @test route(identity, "") isa Function
+end
+
 
 @testset "WebSockets" begin
   import Mux.WebSockets

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using Test
 using HTTP
 import HTTP.ExceptionRequest: StatusError
 
+@testset "Mux" begin
+
 @testset "misc" begin
   function f()
     @app foo = (Mux.defaults)
@@ -136,4 +138,6 @@ end
     @test success
     @test String(data) == message
   end
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,15 +117,15 @@ end
   import Mux.WebSockets
 
   @app h = (
-      Mux.defaults,
-      page("/", respond("<h1>Hello World!</h1>")),
-      Mux.notfound());
-    
+    Mux.defaults,
+    page("/", respond("<h1>Hello World!</h1>")),
+    Mux.notfound());
+
   @app w = (
-      Mux.wdefaults,
-      route("/ws_io", Mux.echo),
-      Mux.wclose,
-      Mux.notfound());
+    Mux.wdefaults,
+    route("/ws_io", Mux.echo),
+    Mux.wclose,
+    Mux.notfound());
 
   serve(h, w, 2333)
 


### PR DESCRIPTION
Changes:

ce32c3b (Colin Caine, 79 seconds ago)
   Test websocket server

1b32062 (Colin Caine, 63 seconds ago)
   Reorganise tests

   Putting them in testsets makes it a bit easier to see what's going on if 
   one of them fails, in my opinion.