### PR TITLE
Use Base.Callable instead of Function in signatures

### DIFF
--- a/src/routing.jl
+++ b/src/routing.jl
@@ -38,14 +38,14 @@ end
 route(p::Vector, app...) = branch(req -> matchpath!(p, req), app...)
 route(p::AbstractString, app...) = route(splitpath(p), app...)
 route(app...) = route([], app...)
-route(app::Function, p) = route(p, app)
-route(app1::Function, app2::Function) = route([], app1, app2)
+route(app::Base.Callable, p) = route(p, app)
+route(app1::Base.Callable, app2::Base.Callable) = route([], app1, app2)
 
 page(p::Vector, app...) = branch(req -> length(p) == length(req[:path]) && matchpath!(p, req), app...)
 page(p::AbstractString, app...) = page(splitpath(p), app...)
 page(app...) = page([], app...)
-page(app::Function, p) = page(p, app)
-page(app1::Function, app2::Function) = page([], app1, app2)
+page(app::Base.Callable, p) = page(p, app)
+page(app1::Base.Callable, app2::Base.Callable) = page([], app1, app2)
 
 # Query routing
 


### PR DESCRIPTION
It's probably a better idea?