### PR TITLE
fix serve api that integrates websockets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Mux"
 uuid = "a975b10e-0019-58db-a62f-e48ff68538c9"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 AssetRegistry = "bf4720bc-e11a-5d0c-854e-bdca1663c893"

--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ function websocket_example(x)
     end
 end
 
-# Serve both servers on two different ports.
-serve(h, w, 2333, 2334)
+# Serve both servers on the same port.
+serve(h, w, 2333)
 ```
 
 And finally, run a client, optionally in another process:
@@ -242,7 +242,7 @@ And finally, run a client, optionally in another process:
 ```julia
 import Mux.WebSockets
 
-WebSockets.open("ws://localhost:2334/ws_io") do ws
+WebSockets.open("ws://localhost:2333/ws_io") do ws
     send(ws, "Hello World!")
     data = receive(ws)
     println(stderr, ws, " received: ", data)

--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ function websocket_example(x)
     end
 end
 
-# Serve both servers on the same port.
-serve(h, w, 2333)
+# Serve both servers on two different ports.
+serve(h, w, 2333, 2334)
 ```
 
 And finally, run a client, optionally in another process:
@@ -242,7 +242,7 @@ And finally, run a client, optionally in another process:
 ```julia
 import Mux.WebSockets
 
-WebSockets.open("ws://localhost:2333/ws_io") do ws
+WebSockets.open("ws://localhost:2334/ws_io") do ws
     send(ws, "Hello World!")
     data = receive(ws)
     println(stderr, ws, " received: ", data)

--- a/src/server.jl
+++ b/src/server.jl
@@ -69,14 +69,16 @@ end
 serve(h::App, port::Integer; kws...) = serve(h, localhost, port; kws...)
 
 """
-    serve(h::App, w::App, host=$localhost, port=$default_port, verbose=false; kwargs...)
-    serve(h::App, w::App, port::Integer)
+    serve(h::App, w::App, host=$localhost, port=$default_port, wsport=port+1; kwargs...)
+    serve(h::App, w::App, port::Integer, wsport::Integer=port+1; kwargs...)
 
 Start a server that uses `h` to serve regular HTTP requests and `w` to serve
 WebSocket requests.
 """
-function serve(h::App, w::App, host = localhost, port = default_port, verbose = false; kws...)
-  @errs WebSockets.listen!(ws_handler(w), host, port; verbose, kws...)
+function serve(h::App, w::App, host = localhost, port = default_port, wsport = port + 1; kws...)
+    hsrvr = @errs HTTP.serve!(http_handler(h), host, port; kws...)
+    wsrvr = @errs WebSockets.listen!(ws_handler(w), host, wsport; kws...)
+    return (hsrvr, wsrvr)
 end
 
-serve(h::App, w::App, port::Integer, verbose = false; kwargs...) = serve(h, w, localhost, port, verbose; kwargs...)
+serve(h::App, w::App, port::Integer, wsport::Integer=port+1; kwargs...) = serve(h, w, localhost, port, wsport; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,9 +131,12 @@ println("WebSockets")
     Mux.wclose,
     Mux.notfound());
 
-  serve(h, w, 2333)
+  serve(h, w, 2333, 2334)
 
-  WebSockets.open("ws://localhost:2333/ws_io") do ws_client
+  @test String(HTTP.get("http://localhost:2333/").body) ==
+    "<h1>Hello World!</h1>"
+
+  WebSockets.open("ws://localhost:2334/ws_io") do ws_client
     message = "Hello WebSocket!"
     WebSockets.send(ws_client, message)
     str = WebSockets.receive(ws_client)
@@ -156,9 +159,11 @@ println("Secure WebSockets")
 
   cert = abspath(joinpath(dirname(pathof(Mux)), "../test", "test.cert"))
   key = abspath(joinpath(dirname(pathof(Mux)), "../test", "test.key"))
-  s = serve(h, w, "127.0.0.1", 2444; sslconfig=MbedTLS.SSLConfig(cert, key))
+  s, sw = serve(h, w, "127.0.0.1", 2444, 2445; sslconfig=MbedTLS.SSLConfig(cert, key))
   # serve(h, w, 2444; sslconfig=MbedTLS.SSLConfig(cert, key))
-  WebSockets.open("wss://localhost:2444/ws_io"; sslconfig=MbedTLS.SSLConfig(false)) do ws_client
+  @test String(HTTP.get("https://localhost:2444/"; sslconfig=MbedTLS.SSLConfig(false)).body) ==
+    "<h1>Hello World!</h1>"
+  WebSockets.open("wss://localhost:2445/ws_io"; sslconfig=MbedTLS.SSLConfig(false)) do ws_client
     message = "Hello WebSocket!"
     WebSockets.send(ws_client, message)
     str = WebSockets.receive(ws_client)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,12 +131,12 @@ println("WebSockets")
     Mux.wclose,
     Mux.notfound());
 
-  serve(h, w, 2333, 2334)
+  serve(h, w, 2333)
 
   @test String(HTTP.get("http://localhost:2333/").body) ==
     "<h1>Hello World!</h1>"
 
-  WebSockets.open("ws://localhost:2334/ws_io") do ws_client
+  WebSockets.open("ws://localhost:2333/ws_io") do ws_client
     message = "Hello WebSocket!"
     WebSockets.send(ws_client, message)
     str = WebSockets.receive(ws_client)
@@ -159,11 +159,10 @@ println("Secure WebSockets")
 
   cert = abspath(joinpath(dirname(pathof(Mux)), "../test", "test.cert"))
   key = abspath(joinpath(dirname(pathof(Mux)), "../test", "test.key"))
-  s, sw = serve(h, w, "127.0.0.1", 2444, 2445; sslconfig=MbedTLS.SSLConfig(cert, key))
-  # serve(h, w, 2444; sslconfig=MbedTLS.SSLConfig(cert, key))
+  serve(h, w, 2444; sslconfig=MbedTLS.SSLConfig(cert, key))
   @test String(HTTP.get("https://localhost:2444/"; sslconfig=MbedTLS.SSLConfig(false)).body) ==
     "<h1>Hello World!</h1>"
-  WebSockets.open("wss://localhost:2445/ws_io"; sslconfig=MbedTLS.SSLConfig(false)) do ws_client
+  WebSockets.open("wss://localhost:2444/ws_io"; sslconfig=MbedTLS.SSLConfig(false)) do ws_client
     message = "Hello WebSocket!"
     WebSockets.send(ws_client, message)
     str = WebSockets.receive(ws_client)


### PR DESCRIPTION
Have a `serve` method that accepts an additional port to listen for websockets. Allows serving both general http requests and websocket requests using a single call to `serve`.

fixes: #146