### PR TITLE
Define `defaults`, `wdefaults` and `prod_defaults` as `const`

### DIFF
--- a/src/Mux.jl
+++ b/src/Mux.jl
@@ -33,8 +33,8 @@ include("examples/mimetypes.jl")
 include("examples/basic.jl")
 include("examples/files.jl")
 
-defaults = stack(todict, basiccatch, splitquery, toresponse, assetserver, pkgfiles)
-wdefaults = stack(todict, wcatch, splitquery)
-prod_defaults = stack(todict, stderrcatch, splitquery, toresponse, assetserver, pkgfiles)
+const defaults = stack(todict, basiccatch, splitquery, toresponse, assetserver, pkgfiles)
+const wdefaults = stack(todict, wcatch, splitquery)
+const prod_defaults = stack(todict, stderrcatch, splitquery, toresponse, assetserver, pkgfiles)
 
 end


### PR DESCRIPTION
I was reading through the code a bit and IMO it would be beneficial to define `defaults`, `wdefaults`, and `prod_defaults` as constants. In that way the compiler has more guarantees which should be helpful when they are used in other functions or downstream code.