### PR TITLE
update websocket example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Here is a complete example:
 
 ```julia
 using Mux
-using HTTP.WebSockets: send
+using Mux.WebSockets: send
 
 # HTTP Server
 @app h = (

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Here is a complete example:
 
 ```julia
 using Mux
+using HTTP.WebSockets: send
 
 # HTTP Server
 @app h = (


### PR DESCRIPTION
I wasn't able to get this to run robustly, this seems to work better. Previously I was getting `send is not defined`, which presumably means that Mux is not exporting `send` from `HTTP.WebSockets`.